### PR TITLE
Fix backend NA guards and remove Promoter-like from frontend

### DIFF
--- a/backend/routes/gwasLD.js
+++ b/backend/routes/gwasLD.js
@@ -51,7 +51,7 @@ const variantBinFinder = async(variants, celltype) => {
         let promoterBin = "";
         let promoterBinArray = [];
         let promoters=[];
-        if (variant._doc.SigHic !== "NA") {
+        if (variant._doc.SigHic && variant._doc.SigHic !== "NA") {
             const regex = /RegulatoryBin:(\d+:\d+:\d+);PromoterBin:((?:\d+:\d+:\d+,?)+)/;
             const match = variant._doc.SigHic.match(regex)
             if (match) {
@@ -73,7 +73,7 @@ const variantBinFinder = async(variants, celltype) => {
 const promoterBinExist = (variants) => {
     let result = false;
     for (let variant of variants) {
-        if (variant._doc.SigHic !== "NA") result = true;
+        if (variant._doc.SigHic && variant._doc.SigHic !== "NA") result = true;
     }
     return result;
 }

--- a/backend/routes/variants.js
+++ b/backend/routes/variants.js
@@ -283,7 +283,7 @@ router.get("/:id", async (req, res) => {
     let extractedPart = "";
     let promoterBin = "";
     let promoterBinArray = [];
-    if (SigHiCRowData !== "NA") {
+    if (SigHiCRowData && SigHiCRowData !== "NA") {
       const regex =
         /RegulatoryBin:(\d+:\d+:\d+);PromoterBin:((?:\d+:\d+:\d+,?)+)/;
       const match = SigHiCRowData.match(regex);

--- a/frontend/src/components/IgvDisease.jsx
+++ b/frontend/src/components/IgvDisease.jsx
@@ -9,7 +9,6 @@ const IgvDisease = ({IndexSNP, celltype, range, diseasePosition}) => {
     const chr = IndexSNP.split("-")[0];
     const locus = `chr${chr}:${range.Start}-${range.End}`;
 
-    let promoter_like_url = `${import.meta.env.VITE_EXPRESS_URL}/public/igv/promoter/promoter_like_regions_annotation_sorted.bed`;
     let genecode_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz"
     // let genecode_url = "/igv/gencode.v35.annotation.sort.gtf.gz";
     let genecode_index_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz.tbi"
@@ -97,13 +96,6 @@ const IgvDisease = ({IndexSNP, celltype, range, diseasePosition}) => {
                     url: `/igv/temp/${IndexSNP}_LD.bed`,
                     height: 50,
                     name: "LD SNP",
-                    displayMode: "EXPANDED",
-                },
-                {
-                    type: "annotation",
-                    format: "bed",
-                    url: promoter_like_url,
-                    name: "Promoter-like-region",
                     displayMode: "EXPANDED",
                 },
                 {

--- a/frontend/src/components/IgvDiseaseWithPromoter.jsx
+++ b/frontend/src/components/IgvDiseaseWithPromoter.jsx
@@ -7,7 +7,6 @@ const IgvDiseaseWithPromoter = ({IndexSNP, celltype, range, diseasePosition}) =>
     const chr = IndexSNP.split("-")[0];
     const locus = `chr${chr}:${range.Start}-${range.End}`;
 
-    let promoter_like_url = `${import.meta.env.VITE_EXPRESS_URL}/public/igv/promoter/promoter_like_regions_annotation_sorted.bed`;
     let genecode_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz"
     // let genecode_url = "/igv/gencode.v35.annotation.sort.gtf.gz";
     let genecode_index_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz.tbi"
@@ -106,13 +105,6 @@ const IgvDiseaseWithPromoter = ({IndexSNP, celltype, range, diseasePosition}) =>
                     url: `/igv/temp/${IndexSNP}_LD.bed`,
                     height: 50,
                     name: "LD SNP",
-                    displayMode: "EXPANDED",
-                },
-                {
-                    type: "annotation",
-                    format: "bed",
-                    url: promoter_like_url,
-                    name: "Promoter-like-region",
                     displayMode: "EXPANDED",
                 },
                 {

--- a/frontend/src/components/IgvVariant.jsx
+++ b/frontend/src/components/IgvVariant.jsx
@@ -10,7 +10,6 @@ const IgvVariant = ({variant, celltype}) => {
   const locus = `chr${variant.Chr}:${start}-${end}`;
   
 
-  let promoter_like_url = `${import.meta.env.VITE_EXPRESS_URL}/public/igv/promoter/promoter_like_regions_annotation_sorted.bed`;
   let genecode_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz"
   // let genecode_url = "/igv/gencode.v35.annotation.sort.gtf.gz";
   let genecode_index_url = "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz.tbi"
@@ -105,14 +104,6 @@ const IgvVariant = ({variant, celltype}) => {
           ],
           name: `${variant.RSID}`,
           height: 50,
-        },
-        {
-          type: "annotation",
-          format: "bed",
-          url: promoter_like_url,
-          height: 50,
-          name: "Promoter-like-region",
-          displayMode: "EXPANDED",
         },
         {
           type: "annotation",

--- a/frontend/src/components/IgvVariantWithPromoter.jsx
+++ b/frontend/src/components/IgvVariantWithPromoter.jsx
@@ -28,10 +28,6 @@ const IgvVariantWithPromoter = ({
   const locus = `chr${variant.Chr}:${startMin}-${endMax}`;
 
   // define the path to target files
-  let promoter_like_url = `${
-    import.meta.env.VITE_EXPRESS_URL
-  }/public/igv/promoter/promoter_like_regions_annotation_sorted.bed`;
-  // let promoter_like_url = "/igv/promoter/promoter_like_regions_annotation_sorted.bed";
   let genecode_url =
     "https://s3.amazonaws.com/igv.org.genomes/hg38/Homo_sapiens.GRCh38.94.chr.gff3.gz";
   // let genecode_url = "/igv/gencode.v35.annotation.sort.gtf.gz";
@@ -160,14 +156,6 @@ const IgvVariantWithPromoter = ({
           ],
           name: `${variant.RSID}`,
           height: 50,
-        },
-        {
-          type: "annotation",
-          format: "bed",
-          url: promoter_like_url,
-          height: 50,
-          name: "Promoter-like-region",
-          displayMode: "EXPANDED",
         },
         {
           type: "annotation",

--- a/frontend/src/pages/genes/genes.jsx
+++ b/frontend/src/pages/genes/genes.jsx
@@ -454,7 +454,7 @@ const Genes = () => {
                     <th>VariantID</th>
                     <th>Region</th>
                     <th>Distance with gene</th>
-                    <th>Promoter-like</th>
+
                     <th>Chromhmm</th>
                     <th>Open Chromatin</th>
                     <th>Hi-C Chromatin Interaction</th>
@@ -477,7 +477,7 @@ const Genes = () => {
                           <td>{region.variantID}</td>
                           <td>{region["Region_Ensembl"]}</td>
                           <td>{region.GeneInfo_DistNG_Ensembl}</td>
-                          <td>{region.Promoter_like_region}</td>
+
                           <td>
                             {celltype === "hMSC"
                               ? region.chromHMM_hMSC
@@ -611,7 +611,7 @@ const Genes = () => {
                     <th>VariantID</th>
                     <th>Region</th>
                     <th>Distance with gene</th>
-                    <th>Promoter-like</th>
+
                     <th>Chromhmm</th>
                     <th>Open Chromatin</th>
                     <th>Hi-C Chromatin Interaction</th>
@@ -634,7 +634,7 @@ const Genes = () => {
                           <td>{region.variantID}</td>
                           <td>{region["Region_Ensembl"]}</td>
                           <td>{region.GeneInfo_DistNG_Ensembl}</td>
-                          <td>{region.Promoter_like_region}</td>
+
                           <td>
                             {celltype === "hMSC"
                               ? region.chromHMM_hMSC

--- a/frontend/src/pages/variants/variants.jsx
+++ b/frontend/src/pages/variants/variants.jsx
@@ -202,12 +202,12 @@ const Variants = () => {
                       {/* {celltype === "hMSC" 
                                         ? variant.chromHMM_hMSC 
                                         : celltype === "Osteoblast"
-                                        ? variant.chromHMM_osteoblast
+                                        ? variant.chromHMM_OB
                                         : "NA"} */}
                       {celltype === "hMSC"
                         ? variant.chromHMM_hMSC
                         : celltype === "Osteoblast"
-                        ? variant.chromHMM_osteoblast
+                        ? variant.chromHMM_OB
                         : celltype === "Osteocyte"
                         ? variant.chromHMM_OC
                         : celltype === "Myoblast" // ADD


### PR DESCRIPTION
Fix backend NA guards and remove Promoter-like from frontend

1. Storage optimization: add undefined guards (field && field !== "NA") in gwasLD.js and variants.js so backend handles missing fields when NA values are omitted from MongoDB documents.
2. Also remove promoter_like_url and IGV track from all 4 IGV components since Promoter-like field no longer exists in variant collection. Fix SigHiC display and waitForBedpe guard in genes.jsx and variants.jsx.